### PR TITLE
Closes #34

### DIFF
--- a/vignettes/graphics.Rmd
+++ b/vignettes/graphics.Rmd
@@ -706,7 +706,7 @@ We can convert x and y values between the different coordinate systems using the
 
 ```{r,fig.width=6,fig.height=4.5,fig.align='center'}
 plot(1:4)
-for(tp in c("in", "dev", "ndc", "nfc", "npc", "nic")) {
+for(tp in c("inches", "device", "ndc", "nfc", "npc", "nic")) {
   newX <- grconvertX(c(1.0, 4.0), "user", tp)
   print(paste(tp, paste(round(newX, 3), collapse = ", "), sep = ": "))
 }
@@ -721,7 +721,7 @@ plot(1:4)
 ```{r,echo=-c(1,2),fig.show='hide'}
 par(oma = c(1, 1, 4, 1), mfrow = c(1, 2))
 plot(1:4)
-for(tp in c("in", "dev", "ndc", "nfc", "npc", "nic")) {
+for(tp in c("inches", "device", "ndc", "nfc", "npc", "nic")) {
   newX <- grconvertX(c(1.0, 4.0), "user", tp)
   print(paste(tp, paste(round(newX, 3), collapse = ", "), sep = ": "))
 }
@@ -736,7 +736,7 @@ box(col = "gray40")
 box(which = "figure", col = "darkred")
 box(which = "inner", col = "darkblue")
 box(which = "outer", col = "darkgreen")
-for(tp in c("in", "dev", "ndc", "nfc", "npc", "nic")) {
+for(tp in c("inches", "device", "ndc", "nfc", "npc", "nic")) {
   mcol <- switch(tp,
                  `in` = "darkorange2",
                  `dev` = "purple3",

--- a/vignettes/graphics.Rmd
+++ b/vignettes/graphics.Rmd
@@ -441,7 +441,7 @@ box(which = "figure", col = "darkred", lwd = 2)
 box(which = "outer", col = "darkgreen", lwd = 4)
 mtext(text = "text for x axis", side = 1, line = 1)
 mtext(text = "text for y axis", side = 2, line = 1)
-mtext(text = "text for outer title", side = 3, line = 2)
+mtext(text = "text for outer title", side = 3, line = 1, outer = TRUE)
 ```
 
 For scientific plotting, you should read `?plotmath` which describes how to add special symbols and forumulae to your plots.  
@@ -552,7 +552,7 @@ The following gives a mostly complete list of other the functions for drawing in
 |------------|-----------------------------------------------------|
 | `lines`    | Draw lines between the given coordinates            | 
 | `polygon`  | Draw polygon with vertices at the given coordinates | 
-| `abline`   | Draw lines according to $y = ax + b$                | 
+| `abline`   | Draw lines according to $y = bx + a$                | 
 | `arrows`   | Draw lines with arrow heads                         | 
 | `curve`    | Draw the given expression                           | 
 | `segments` | Draw segments between the given pairs of points     |


### PR DESCRIPTION
Closes #34 

Previously, the last call to mtext in the text
section did not have the outer flag which is what
it was intended to show. Also, the definition of
abline had 'a' and 'b' backwards.