### PR TITLE
issue-45: new install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To install the package from github run:
 
 ```
 library(devtools)
-install_github("How-to-Learn-to-Code/rclass", build_vignettes = TRUE)
+devtools::install_github("How-to-Learn-to-Code/rclass", build_opts = "")
 library(htltcR)
 ```
 Then you can load vignettes for each lecture. For example, to run load the lecture for class1 simply run:


### PR DESCRIPTION
Install instructions now work for most recent devtools version.